### PR TITLE
Added git branch for sqlparser latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,8 +124,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?branch=main#c8b7f7cf4281cdfff3e08e9827928662b8be8095"
 dependencies = [
  "log",
  "recursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ default = []
 fuzzing = []
 
 [dependencies]
-sqlparser = "0.60.0"
-
+sqlparser = { version = "0.60.0", git = "https://github.com/apache/datafusion-sqlparser-rs", branch = "main" }
 
 [lints.rust]
 missing_docs = "forbid"


### PR DESCRIPTION
This way, when working via git URL, the latest version of sqlparser is used. They added support for parsing [RLS](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) just last week, and I am working on implementing exactly that in the portal schema.

Luca